### PR TITLE
Properly load Second

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rack-throttle (0.3.0)
+    rack-throttle (0.4.0)
       rack (>= 1.0.0)
 
 GEM

--- a/lib/rack/throttle.rb
+++ b/lib/rack/throttle.rb
@@ -8,6 +8,7 @@ module Rack
     autoload :Daily,      'rack/throttle/daily'
     autoload :Hourly,     'rack/throttle/hourly'
     autoload :Minute,     'rack/throttle/minute'
+    autoload :Second,     'rack/throttle/second'
     autoload :VERSION,    'rack/throttle/version'
   end
 end

--- a/spec/second_spec.rb
+++ b/spec/second_spec.rb
@@ -1,0 +1,35 @@
+require File.dirname(__FILE__) + '/spec_helper'
+
+describe Rack::Throttle::Second do
+  include Rack::Test::Methods
+
+  def app
+    @target_app ||= example_target_app
+    @app ||= Rack::Throttle::Second.new(@target_app, :max => 3)
+  end
+
+  it "should be allowed if not seen this second" do
+    get "/foo"
+    last_response.body.should show_allowed_response
+  end
+  
+  it "should be allowed if seen fewer than the max allowed per second" do
+    2.times { get "/foo" }
+    last_response.body.should show_allowed_response
+  end
+  
+  it "should not be allowed if seen more times than the max allowed per second" do
+    4.times { get "/foo" }
+    last_response.body.should show_throttled_response
+  end
+  
+  it "should not count last minute's requests against this second's" do
+    Timecop.freeze(DateTime.now - 1/86400.0) do
+      4.times { get "/foo" }
+      last_response.body.should show_throttled_response
+    end
+
+    get "/foo"
+    last_response.body.should show_allowed_response
+  end
+end


### PR DESCRIPTION
It wasn't loaded...

Added a test, but having a hard time running it because old time rspec.

Things I tried on running the test:

```
bundle exec rspec spec # Uses 3.x
bundle exec ruby -I"lib:rspec" spec/second_spec.rb" # This should work... But it doesn't.
```

I guess if I look it up I can figure it out, but it's 6.30 in the morning and I don't really have time :-)