### PR TITLE
Replace "hour" with "minute" in Minute throttler

### DIFF
--- a/lib/rack/throttle/minute.rb
+++ b/lib/rack/throttle/minute.rb
@@ -12,7 +12,7 @@ module Rack; module Throttle
   # @example Allowing up to 60 requests/minute
   #   use Rack::Throttle::Minute
   #
-  # @example Allowing up to 100 requests per hour
+  # @example Allowing up to 100 requests per minute
   #   use Rack::Throttle::Minute, :max => 100
   #
   class Minute < TimeWindow
@@ -26,7 +26,7 @@ module Rack; module Throttle
 
     ##
     def max_per_minute
-      @max_per_hour ||= options[:max_per_minute] || options[:max] || 60
+      @max_per_minute ||= options[:max_per_minute] || options[:max] || 60
     end
 
     alias_method :max_per_window, :max_per_minute


### PR DESCRIPTION
Nothing spectacular, just two typo fixes for the Minute throttler I came across while reading the source code.